### PR TITLE
Add PoC RAG chatbot with WordPress integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# OpenAI API key
+OPENAI_API_KEY=
+
+# Azure AD tenant and API client ID
+AZURE_TENANT_ID=
+AZURE_API_CLIENT_ID=

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,86 @@
+"""Streamlit-backed FastAPI app for a RAG chatbot.
+
+Run with `uvicorn backend.app:app` or `streamlit run backend/app.py`.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+import jwt
+from dotenv import load_dotenv
+from fastapi import Depends, FastAPI, Header, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from jwt import PyJWKClient
+from langchain.chains import RetrievalQA
+from langchain.chat_models import ChatOpenAI
+from langchain.embeddings.openai import OpenAIEmbeddings
+from langchain.vectorstores import Chroma
+import streamlit as st
+
+load_dotenv()
+
+# Azure AD config for validating JWT access tokens
+TENANT_ID = os.getenv("AZURE_TENANT_ID")
+API_CLIENT_ID = os.getenv("AZURE_API_CLIENT_ID")
+JWKS_URL = f"https://login.microsoftonline.com/{TENANT_ID}/discovery/v2.0/keys"
+
+# Initialise persistent Chroma store and retrieval chain
+PERSIST_DIR = "./data"
+embedding = OpenAIEmbeddings()
+vectordb = Chroma(persist_directory=PERSIST_DIR, embedding_function=embedding)
+qa_chain = RetrievalQA.from_chain_type(
+    llm=ChatOpenAI(model="gpt-4o-mini"),
+    chain_type="stuff",
+    retriever=vectordb.as_retriever(),
+)
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["https://example.com"],
+    allow_methods=["POST"],
+    allow_headers=["*"],
+)
+
+
+def verify_token(authorization: str | None = Header(default=None)) -> Dict:
+    """Verify Azure AD access token sent in the Authorization header."""
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing token")
+    token = authorization.split()[1]
+    try:
+        jwks_client = PyJWKClient(JWKS_URL)
+        signing_key = jwks_client.get_signing_key_from_jwt(token)
+        payload = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=["RS256"],
+            audience=API_CLIENT_ID,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+    if "chat.access" not in payload.get("scp", "").split():
+        raise HTTPException(status_code=403, detail="Missing scope")
+    return payload
+
+
+@app.post("/chat")
+async def chat(body: Dict[str, str], _token: Dict = Depends(verify_token)) -> Dict[str, str]:
+    """Answer questions using the retrieval chain."""
+    query = body.get("query", "")
+    answer = qa_chain.run(query)
+    return {"answer": answer}
+
+
+# Simple Streamlit screen for manual testing
+if st.runtime.exists():  # Script is running under Streamlit
+    st.title("Chat API")
+    st.write("POST queries to `/chat` with a valid bearer token.")
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend/ingest.py
+++ b/backend/ingest.py
@@ -1,0 +1,29 @@
+"""Build the persistent Chroma index from Markdown files in ./docs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from langchain.document_loaders import TextLoader
+from langchain.embeddings.openai import OpenAIEmbeddings
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.vectorstores import Chroma
+
+PERSIST_DIR = "./data"
+DOCS_DIR = Path(__file__).resolve().parents[1] / "docs"
+
+
+def main() -> None:
+    documents = []
+    splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=50)
+    for md_file in DOCS_DIR.glob("*.md"):
+        loader = TextLoader(str(md_file))
+        docs = loader.load()
+        documents.extend(splitter.split_documents(docs))
+    embedding = OpenAIEmbeddings()
+    Chroma.from_documents(documents, embedding, persist_directory=PERSIST_DIR)
+    print(f"Indexed {len(documents)} chunks")
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,26 @@
+# My Chat Widget
+
+This folder contains `my-chat.js`, a Lit-based WebComponent that authenticates users with Microsoft Entra ID using MSAL.js and communicates with the backend chatbot API.
+
+## Azure App Registration
+1. Create an **API** app registration:
+   - Expose an API scope `chat.access`.
+   - Note the *Application (client) ID* and set it as `AZURE_API_CLIENT_ID`.
+2. Create an **SPA** app registration for the frontend:
+   - Add a redirect URI `http://localhost` (or your domain).
+   - In **API permissions** add the `chat.access` scope from the API app.
+   - Note the SPA client ID and tenant ID for use in `MY_CHAT_CONFIG`.
+
+## WordPress Integration
+Copy the plugin and theme from `wordpress/` into your existing WordPress installation:
+
+1. `wp-content/plugins/my-chat-embed/`
+2. `wp-content/themes/chat-demo/`
+
+Activate both via the WordPress admin panel. Define the API base URL in `wp-config.php`:
+
+```php
+define('MY_CHAT_API_BASE', 'https://your-backend-host');
+```
+
+Once activated, visit `/chat/` on your site to see the embedded `<my-chat>` widget.

--- a/frontend/my-chat.js
+++ b/frontend/my-chat.js
@@ -1,0 +1,66 @@
+// Minimal LitElement chat widget with MSAL authentication
+import {LitElement, html, css} from 'https://unpkg.com/lit@2/index.js?module';
+import {PublicClientApplication} from 'https://alcdn.msauth.net/browser/2.38.0/js/msal-browser.esm.min.js';
+
+class MyChat extends LitElement {
+  static properties = {
+    messages: {state: true},
+    token: {state: true}
+  };
+
+  static styles = css`
+    :host{display:block;border:1px solid #ccc;padding:8px;width:300px;font-family:sans-serif}
+    .messages{max-height:200px;overflow-y:auto;border:1px solid #ddd;padding:4px;margin-bottom:4px}
+    .messages div{margin-bottom:4px}
+    input{width:100%;box-sizing:border-box}
+  `;
+
+  constructor(){
+    super();
+    const cfg = window.MY_CHAT_CONFIG || {};
+    this.apiBase = cfg.apiBase || '';
+    this.clientId = cfg.clientId || '';
+    this.tenantId = cfg.tenantId || '';
+    this.messages = [];
+    this.token = null;
+    this.msal = new PublicClientApplication({
+      auth: {clientId: this.clientId, authority: `https://login.microsoftonline.com/${this.tenantId}`},
+      cache: {cacheLocation: 'sessionStorage'}
+    });
+  }
+
+  render(){
+    return this.token ? this.renderChat() : html`<button @click=${this.login}>Login</button>`;
+  }
+
+  renderChat(){
+    return html`
+      <div class="messages">
+        ${this.messages.map(m => html`<div><b>${m.from}:</b> ${m.text}</div>`)}
+      </div>
+      <input placeholder="Ask..." @keydown=${this.handleKey} />
+    `;
+  }
+
+  async login(){
+    const result = await this.msal.loginPopup({scopes:['chat.access']});
+    this.token = result.accessToken;
+  }
+
+  async handleKey(e){
+    if(e.key==='Enter' && e.target.value.trim()){
+      const text = e.target.value.trim();
+      e.target.value='';
+      this.messages = [...this.messages,{from:'user',text}];
+      const res = await fetch(`${this.apiBase}/chat`,{
+        method:'POST',
+        headers:{'Content-Type':'application/json',Authorization:`Bearer ${this.token}`},
+        body:JSON.stringify({query:text})
+      });
+      const data = await res.json();
+      this.messages = [...this.messages,{from:'assistant',text:data.answer}];
+    }
+  }
+}
+
+customElements.define('my-chat', MyChat);

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+fastapi
+uvicorn
+streamlit
+langchain
+chromadb
+openai
+PyJWT
+python-dotenv
+requests

--- a/wordpress/wp-content/plugins/my-chat-embed/my-chat-embed.js
+++ b/wordpress/wp-content/plugins/my-chat-embed/my-chat-embed.js
@@ -1,0 +1,50 @@
+// WordPress bundle of the my-chat widget
+import {LitElement, html, css} from 'https://unpkg.com/lit@2/index.js?module';
+import {PublicClientApplication} from 'https://alcdn.msauth.net/browser/2.38.0/js/msal-browser.esm.min.js';
+
+class MyChat extends LitElement {
+  static properties = {messages:{state:true},token:{state:true}};
+  static styles = css`
+    :host{display:block;border:1px solid #ccc;padding:8px;width:300px;font-family:sans-serif}
+    .messages{max-height:200px;overflow-y:auto;border:1px solid #ddd;padding:4px;margin-bottom:4px}
+    .messages div{margin-bottom:4px}
+    input{width:100%;box-sizing:border-box}
+  `;
+  constructor(){
+    super();
+    const cfg = window.MY_CHAT_CONFIG || {};
+    this.apiBase = cfg.apiBase || '';
+    this.clientId = cfg.clientId || '';
+    this.tenantId = cfg.tenantId || '';
+    this.messages=[];
+    this.token=null;
+    this.msal = new PublicClientApplication({
+      auth:{clientId:this.clientId,authority:`https://login.microsoftonline.com/${this.tenantId}`},
+      cache:{cacheLocation:'sessionStorage'}
+    });
+  }
+  render(){
+    return this.token?this.renderChat():html`<button @click=${this.login}>Login</button>`;
+  }
+  renderChat(){
+    return html`<div class="messages">${this.messages.map(m=>html`<div><b>${m.from}:</b> ${m.text}</div>`)}</div>
+    <input placeholder="Ask..." @keydown=${this.handleKey}/>`;
+  }
+  async login(){
+    const result=await this.msal.loginPopup({scopes:['chat.access']});
+    this.token=result.accessToken;
+  }
+  async handleKey(e){
+    if(e.key==='Enter'&&e.target.value.trim()){
+      const text=e.target.value.trim();
+      e.target.value='';
+      this.messages=[...this.messages,{from:'user',text}];
+      const r=await fetch(`${this.apiBase}/chat`,{method:'POST',headers:{'Content-Type':'application/json',Authorization:`Bearer ${this.token}`},body:JSON.stringify({query:text})});
+      const d=await r.json();
+      this.messages=[...this.messages,{from:'assistant',text:d.answer}];
+    }
+  }
+}
+if(!customElements.get('my-chat')){
+  customElements.define('my-chat', MyChat);
+}

--- a/wordpress/wp-content/plugins/my-chat-embed/my-chat-embed.php
+++ b/wordpress/wp-content/plugins/my-chat-embed/my-chat-embed.php
@@ -1,0 +1,26 @@
+<?php
+/*
+Plugin Name: My Chat Embed
+Description: Provides [my_chat] shortcode for embedding the chat widget.
+*/
+
+// Enqueue the JS and pass settings from wp-config.php or options
+function my_chat_enqueue(){
+    $plugin_url = plugin_dir_url(__FILE__);
+    wp_enqueue_script('my-chat-embed', $plugin_url . 'my-chat-embed.js', [], '1.0', true);
+    $cfg = [
+        'apiBase' => defined('MY_CHAT_API_BASE') ? MY_CHAT_API_BASE : get_option('my_chat_api_base', ''),
+        'clientId' => get_option('my_chat_client_id', ''),
+        'tenantId' => get_option('my_chat_tenant_id', ''),
+        'widgetUrl' => $plugin_url . 'my-chat-embed.js',
+    ];
+    wp_localize_script('my-chat-embed', 'MY_CHAT_CONFIG', $cfg);
+}
+add_action('wp_enqueue_scripts', 'my_chat_enqueue');
+
+// Shortcode output
+function my_chat_shortcode(){
+    return '<my-chat></my-chat>';
+}
+add_shortcode('my_chat', 'my_chat_shortcode');
+?>

--- a/wordpress/wp-content/themes/chat-demo/functions.php
+++ b/wordpress/wp-content/themes/chat-demo/functions.php
@@ -1,0 +1,6 @@
+<?php
+// Minimal child theme setup
+add_action('wp_enqueue_scripts', function(){
+    $parent = wp_get_theme(get_template());
+    wp_enqueue_style('parent-style', get_template_directory_uri().'/style.css', [], $parent->get('Version'));
+});

--- a/wordpress/wp-content/themes/chat-demo/page-chat.php
+++ b/wordpress/wp-content/themes/chat-demo/page-chat.php
@@ -1,0 +1,9 @@
+<?php
+/* Template Name: Chat Page */
+get_header();
+?>
+<main id="primary" class="site-main">
+<?php echo do_shortcode('[my_chat]'); ?>
+</main>
+<?php
+get_footer();


### PR DESCRIPTION
## Summary
- implement backend FastAPI app with Streamlit UI
- add ingest script to build Chroma index
- create LitElement chat widget with MSAL auth
- document setup and WordPress integration
- provide minimal WordPress plugin and child theme

## Testing
- `python -m py_compile backend/app.py backend/ingest.py`

------
https://chatgpt.com/codex/tasks/task_e_6867f46448f483328a2f0b8d33aeef47